### PR TITLE
fix: cicd infra push 권한 설정 수정

### DIFF
--- a/.github/workflows/backend-ci-cd.yaml
+++ b/.github/workflows/backend-ci-cd.yaml
@@ -126,7 +126,7 @@ jobs:
         with:
           repository: CLD3rd-Team4/Infra
           ref: dev
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.INFRA_PAT }}
           path: infra
 
       - name: Update YAMLs with new image tags

--- a/backend/gateway/src/main/resources/application.yaml
+++ b/backend/gateway/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ management:
       enabled: true
 
 jwt:
-  secret: 
+  secret: tmp
   expiration: 86400000
 
 server:


### PR DESCRIPTION
## ✅ 요약
backend ci/cd코드: infra에 push할 수 있는 토큰을 secret 변수로 주입하도록 수정했습니다.
