### PR TITLE
fix: Auth 서비스 Config Server 연결 URL 수정

### DIFF
--- a/backend/auth/src/main/resources/application.yaml
+++ b/backend/auth/src/main/resources/application.yaml
@@ -3,4 +3,4 @@ spring:
     name: auth
 
   config:
-    import: optional:configserver:http://config-server.service-platform.svc.cluster.local:8888
+    import: optional:configserver:http://config.service-platform.svc.cluster.local:8888


### PR DESCRIPTION
- Auth 서비스의 Config Server URL을 올바른 Service 이름으로 수정
- config-server.service-platform.svc.cluster.local → config.service-platform.svc.cluster.local
- 실제 Kubernetes Service 이름과 일치하도록 변경
- 이제 Auth 서비스가 Config Server에서 설정을 정상적으로 가져올 수 있음
- 네트워크 연결 문제 해결로 완전한 Config Server 연동 완성