### PR TITLE
fix: Auth 서비스 PostgreSQL 설정 및 Spring Boot 3.5.3 업데이트

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -20,7 +20,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring-cloud.version>2023.0.1</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
 
     <dependencies>
@@ -80,6 +80,13 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- PostgreSQL Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/config-repo/auth.yml
+++ b/config-repo/auth.yml
@@ -9,12 +9,15 @@ spring:
     url: "{cipher}569c1c314da35d12120495ae86e04d2b7b668f18b0f3747e26687ed19d7c0e9875d5c81e113db1148c64521ab8a22f2980fbb0d71012ec823930dd12b880baf9fc937984ef4382cb3bcf38f734e33e589f01479e303eef6189492fe08cb3068436befc18b5090db00d0d0b62d3f847b6b3ab4dcb237b862399fce68501857c20"
     username: "{cipher}995dfde6ea6ecd8bbd5a0ee2910a702e005be23ab5892cf6d95f4fca0d1b11ab"
     password: "{cipher}9bd7424c08e3de951c830c47941f93c33ae97a808789991e1df5bd5d062d8774"
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
   security:
     oauth2:


### PR DESCRIPTION
## 🔧 수정사항

### Auth 서비스 PostgreSQL 설정 수정
- PostgreSQL 드라이버 의존성 추가 (pom.xml)
- MySQL → PostgreSQL 드라이버 변경 (config-repo/auth.yml)
- PostgreSQL Hibernate dialect 추가

### 버전 업데이트  
- Spring Boot 3.3.5 → 3.5.3
- Spring Cloud 2023.0.1 → 2024.0.0

## 🚨 해결하는 문제
- Auth Pod CrashLoopBackOff 문제 해결
- `Cannot load driver class: com.mysql.cj.jdbc.Driver` 에러 해결

## 🧪 테스트
- [ ] Auth Pod 정상 시작 확인
- [ ] PostgreSQL 연결 확인