### PR TITLE
fix: OAuth2 클라이언트 authentication methods 추가

### DIFF
--- a/config-repo/auth.yml
+++ b/config-repo/auth.yml
@@ -27,6 +27,9 @@ spring:
             registration:
               client-id: "mapzip-client"
               client-secret: "{cipher}e12398d0e53e0cfc0b02b86dfc9eb5c2c118b8ebb82196be473afcf3645128d860659d41fcef7c7e67eb34658d12bd3e"
+              client-authentication-methods:
+                - client_secret_basic
+                - client_secret_post
               authorization-grant-types:
                 - authorization_code
                 - refresh_token


### PR DESCRIPTION
## 🔧 수정사항

### OAuth2 클라이언트 설정 완성
- `client-authentication-methods` 설정 추가
- `client_secret_basic`, `client_secret_post` 지원

## 🚨 해결하는 문제
- Auth 서비스 `Client authentication methods must not be empty` 에러 해결

## 🧪 테스트
- [ ] Auth Pod 정상 시작 확인
- [ ] OAuth2 인증 서버 정상 동작 확인