### PR TITLE
chore: Auth 서비스 Docker 이미지 재빌드 트리거

### DIFF
--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/AuthServiceApplication.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/AuthServiceApplication.java
@@ -3,6 +3,7 @@ package com.mapzip.auth.auth_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
 @SpringBootApplication
 public class AuthServiceApplication {
 


### PR DESCRIPTION
## 🔄 목적

OAuth2 설정 변경사항을 새로운 Docker 이미지에 반영하기 위한 재빌드

## 🔧 변경사항
- Auth 서비스 메인 클래스에 빈 줄 추가 (코드 변경 감지용)

## 🎯 기대 효과
- 새로운 Docker 이미지 빌드 및 배포
- OAuth2 `client-authentication-methods` 설정 적용
- Auth Pod 정상 시작