### PR TITLE
fix: Spring Security OAuth2 Authorization Server 버전 호환성 수정

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-authorization-server</artifactId>
-            <version>1.1.2</version>
+            <version>1.4.1</version>
         </dependency>
 
         <!-- Eureka Client -->


### PR DESCRIPTION
## 🚨 해결하는 문제

Auth 서비스에서 발생하는 버전 호환성 에러:
```
NoSuchMethodError: 'org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings$Builder org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings$Builder.multipleIssuersAllowed(boolean)'
```

## 🔧 수정사항

- Spring Security OAuth2 Authorization Server: **1.1.2** → **1.4.1**
- Spring Boot 3.5.3과 호환되는 버전으로 업데이트

## 🧪 테스트
- [ ] Auth Pod 정상 시작 (2/2 Running)
- [ ] OAuth2 인증 서버 정상 동작