### PR TITLE
fix: Auth 서비스 Spring Cloud 호환성 문제 해결

### DIFF
--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/AuthServiceApplication.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/AuthServiceApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 
+
 @SpringBootApplication
 public class AuthServiceApplication {
 

--- a/config-repo/auth.yml
+++ b/config-repo/auth.yml
@@ -41,6 +41,8 @@ spring:
               require-authorization-consent: true
 
   cloud:
+    compatibility-verifier:
+      enabled: false
     kubernetes:
       discovery:
         enabled: true


### PR DESCRIPTION
## 🚨 해결하는 문제

Auth 서비스에서 발생하는 Spring Cloud 호환성 체크로 인한 시작 실패:
```
Spring Boot [3.5.3] is not compatible with this Spring Cloud release train
```

## 🔧 수정사항

### 1. Spring Cloud 호환성 체크 비활성화
- `spring.cloud.compatibility-verifier.enabled=false` 설정 추가

### 2. Docker 이미지 재빌드 트리거
- Auth 서비스 메인 클래스에 빈 줄 추가

## 🧪 테스트
- [ ] Auth Pod 정상 시작 (2/2 Running)
- [ ] Spring Cloud 호환성 체크 우회
- [ ] OAuth2 인증 서버 정상 동작

## 📋 전체 해결 내역
1. ✅ PostgreSQL 드라이버 추가
2. ✅ Spring Boot 3.5.3 업데이트  
3. ✅ OAuth2 client-authentication-methods 추가
4. ✅ Spring Security OAuth2 Authorization Server 버전 호환성 수정
5. ✅ Spring Cloud 호환성 체크 비활성화