### PR TITLE
feat: Auth 서비스 Spring Cloud 2025.0.0으로 통일

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/config-repo/auth.yml
+++ b/config-repo/auth.yml
@@ -41,8 +41,6 @@ spring:
               require-authorization-consent: true
 
   cloud:
-    compatibility-verifier:
-      enabled: false
     kubernetes:
       discovery:
         enabled: true


### PR DESCRIPTION
## 🎯 목적

Auth 서비스를 다른 서비스들과 동일한 Spring Cloud 버전으로 통일

## 🔧 변경사항

### 1. Spring Cloud 버전 업데이트
- **Auth 서비스**: Spring Cloud 2024.0.0 → **2025.0.0**
- Gateway, Config, Review 서비스와 버전 통일

### 2. 호환성 체크 정상화
- `spring.cloud.compatibility-verifier.enabled=false` 제거
- Spring Boot 3.5.3 + Spring Cloud 2025.0.0 정상 호환

## 📊 **전체 서비스 버전 통일 현황**

| 서비스 | Spring Boot | Spring Cloud | 상태 |
|--------|-------------|--------------|------|
| Gateway | 3.5.4 | 2025.0.0 | ✅ 정상 |
| Config | 3.5.3 | 2025.0.0 | ✅ 정상 |
| Review | 3.5.3 | 2025.0.0 | ✅ 정상 |
| **Auth** | 3.5.3 | **2025.0.0** | ✅ **업데이트** |
| Schedule | 3.5.3 | 2023.0.0 | 🔄 업데이트 필요 |

## 🧪 테스트
- [ ] Auth Pod 정상 시작 (2/2 Running)
- [ ] Spring Cloud 호환성 체크 통과
- [ ] Gateway와 Auth 서비스 간 통신 정상
- [ ] OAuth2 인증 서버 정상 동작

## 🎉 기대 효과
- 모든 서비스 간 버전 일관성 확보
- 호환성 문제 해결
- 안정적인 마이크로서비스 통신