### PR TITLE
feat: Schedule 서비스 Spring Cloud 2025.0.0으로 업데이트

### DIFF
--- a/backend/schedule/pom.xml
+++ b/backend/schedule/pom.xml
@@ -32,7 +32,7 @@
 		<protobuf.version>3.25.3</protobuf.version>
 		<grpc.version>1.62.2</grpc.version>
 		<aws.version>2.20.26</aws.version>
-		<spring-cloud.version>2023.0.0</spring-cloud.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 
 	<dependencyManagement>
@@ -80,6 +80,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		
+		<!-- PostgreSQL 드라이버 -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
## 🎯 목적

Schedule 서비스의 Spring Cloud 호환성 문제 해결 및 다른 서비스들과 버전 통일

## 🚨 해결하는 문제

Schedule 서비스에서 발생하는 Spring Cloud 호환성 체크로 인한 시작 실패:
```
Spring Boot [3.5.3] is not compatible with this Spring Cloud release train
```

## 🔧 변경사항

### 1. Spring Cloud 버전 업데이트
- **Schedule 서비스**: Spring Cloud 2023.0.0 → **2025.0.0**
- Gateway, Config, Review, Auth 서비스와 버전 통일

### 2. PostgreSQL 드라이버 추가
- `org.postgresql:postgresql` 의존성 추가
- PostgreSQL 데이터베이스 연결 지원

## 📊 **전체 서비스 버전 통일 현황**

| 서비스 | Spring Boot | Spring Cloud | 상태 |
|--------|-------------|--------------|------|
| Gateway | 3.5.4 | 2025.0.0 | ✅ 정상 |
| Config | 3.5.3 | 2025.0.0 | ✅ 정상 |
| Review | 3.5.3 | 2025.0.0 | ✅ 정상 |
| Auth | 3.5.3 | 2025.0.0 | ✅ 정상 |
| **Schedule** | 3.5.3 | **2025.0.0** | ✅ **업데이트** |

## 🧪 테스트
- [ ] Schedule Pod 정상 시작 (2/2 Running)
- [ ] Spring Cloud 호환성 체크 통과
- [ ] PostgreSQL 연결 정상
- [ ] gRPC 서비스 정상 동작

## 🎉 기대 효과
- Schedule Pod CrashLoopBackOff 해결
- 모든 마이크로서비스 간 버전 일관성 확보
- 안정적인 서비스 간 통신
- PostgreSQL 데이터베이스 정상 연결