### PR TITLE
feat: gateway cors설정 및 라우팅 포트 변경

### DIFF
--- a/backend/gateway/src/main/java/mapzip/gateway/config/CustomRouteLocator.java
+++ b/backend/gateway/src/main/java/mapzip/gateway/config/CustomRouteLocator.java
@@ -27,14 +27,14 @@ public class CustomRouteLocator {
                         .filters(f -> f
                                 .filter(xssProtectionFilter.apply(new XssProtectionFilter.Config()))
                                 .filter(jwtAuthenticationFilter.apply(new JwtAuthenticationFilter.Config())))
-                        .uri("http://auth.service-platform:50051"))
+                        .uri("http://auth.service-platform:8080"))
 
                 // 추천 서비스 라우팅
                 .route("recommend-service", r -> r.path("/recommend/**")
                         .filters(f -> f
                                 .filter(xssProtectionFilter.apply(new XssProtectionFilter.Config()))
                                 .filter(jwtAuthenticationFilter.apply(new JwtAuthenticationFilter.Config())))
-                        .uri("http://recommend.service-recommend:50051"))
+                        .uri("http://recommend.service-recommend:9090"))
 
                 // 리뷰 서비스 라우팅 (이미지 포함 - HTTP)
                 .route("review-http", r -> r.path("/review", "/review/verify-receipt")

--- a/backend/gateway/src/main/java/mapzip/gateway/filter/JwtAuthenticationFilter.java
+++ b/backend/gateway/src/main/java/mapzip/gateway/filter/JwtAuthenticationFilter.java
@@ -39,8 +39,8 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory<JwtAut
 
             log.info("JWT Filter - Request: {} {}", request.getMethod(), path);
 
-            // 로그인 요청은 JWT 검증 제외
-            if (path.startsWith("/auth/kakao/login")) {
+            // 로그인 요청, 액세스 토큰 쿠키 재발급 요청은 JWT 검증 제외
+            if (path.startsWith("/auth/kakao/login")|| path.startsWith("/auth/token/refresh")) {
                 log.info("JWT Filter - Skipping auth for login path: {}", path);
                 return chain.filter(exchange);
             }

--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -25,10 +25,11 @@ management:
   endpoint:
     health:
       show-details: always
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: ${PROMETHEUS_ENABLED:true}
+
 
 # 로깅 설정 (운영 환경 기준)
 logging:

--- a/config-repo/gateway.yml
+++ b/config-repo/gateway.yml
@@ -6,6 +6,21 @@ spring:
   cloud:
     config:
       enabled: true
+    gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowed-origins: 
+              - "https://www.mapzip.shop"
+            allowed-methods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+            allowed-headers: "*"
+            allow-credentials: true
+            max-age: 3600
 
 management:
   endpoints:

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,6 +1,7 @@
 // API 기본 설정
 const API_BASE_URL = "https://api.mapzip.shop";
 
+
 // 테스트용 데이터 - 실제 API 연동 시 제거
 const TEST_DATA = {
   schedules: [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "target": "ES6",
     "skipLibCheck": true,
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "out/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## ✅ 요약
- 게이트웨이에서 https://www.mapzip.shop에서 오는 브라우저 요청에 대해, 인증 쿠키를 포함한 모든 메서드·헤더의 요청을 허용하고, CORS preflight 결과를 3600초(1시간) 동안 브라우저에 캐시하도록 설정했습니다.
- 추천서버 포트 9090, 인증서버 포트 8080으로 라우팅되도록 수정했습니다.
- 액세스토큰 리프레쉬 요청은 jwt검증을 하지 않도록 수정했습니다.
