### PR TITLE
fix: Add explicit version for AWS S3 Presigner dependency

### DIFF
--- a/backend/review/pom.xml
+++ b/backend/review/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-presigner</artifactId>
+            <version>2.21.29</version>
         </dependency>
 
         <!-- Google Cloud Vision API -->


### PR DESCRIPTION
## 🔧 수정 내용

### AWS S3 Presigner 의존성 버전 문제 해결

**파일**: `backend/review/pom.xml`

#### 문제 상황
GitHub Actions에서 Review 서비스 빌드 실패:
```
'dependencies.dependency.version' for software.amazon.awssdk:s3-presigner:jar is missing. @ line 74, column 21
```

#### 원인
- AWS SDK BOM에서 `s3-presigner` 의존성이 관리되지 않음
- 명시적 버전 없이 BOM에만 의존하려 했으나 실패

#### 해결 방법
- **S3 Presigner에 명시적 버전 추가**: `2.21.29`
- 다른 AWS SDK 의존성들과 동일한 버전으로 통일

## 🚨 해결하려는 문제

### GitHub Actions 빌드 실패
- **현재 상태**: Review 서비스 Maven 빌드 실패
- **오류**: S3 Presigner 의존성 버전 누락
- **영향**: Review 서비스 Docker 이미지 생성 불가

### Review 서비스 배포 문제
- **현재 상태**: `ImagePullBackOff` (ECR 이미지 없음)
- **원인**: 빌드 실패로 인한 이미지 생성 불가
- **해결**: 성공적인 빌드 → ECR 푸시 → 정상 배포

## 🔄 예상 동작

1. **PR 머지** → **GitHub Actions 재실행**
2. **Review 서비스 Maven 빌드 성공** → **Docker 이미지 생성**
3. **ECR에 이미지 푸시** → **ArgoCD YAML 업데이트**
4. **Review Pod 정상 배포** → **ImagePullBackOff 해결**

## ✅ 검증 완료

- Maven 의존성 버전 명시적 지정 확인
- AWS SDK 다른 의존성들과 버전 일치 확인
- S3 Presigner 2.21.29 버전 존재 확인

## 📋 관련 이슈

- **이전 PR**: #68 (Review 의존성 호환성 문제 해결)
- **연관 문제**: Review 서비스 ImagePullBackOff
- **GitHub Actions**: Backend CI/CD 워크플로우 실패

이 수정으로 Review 서비스가 정상적으로 빌드되고 배포될 수 있습니다.