### PR TITLE
fix: Config CI/CD 중복 재시작 문제 해결

### DIFF
--- a/.github/workflows/config-ci-cd.yaml
+++ b/.github/workflows/config-ci-cd.yaml
@@ -27,6 +27,9 @@ jobs:
         run: |
           git fetch origin dev
           
+          # Backend 변경사항도 확인 (중복 재시작 방지)
+          BACKEND_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^backend/' | cut -d '/' -f2 | sort | uniq)
+          
           # config-repo/application.yml 변경 확인
           APPLICATION_CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^config-repo/application\.yml$' | wc -l)
           
@@ -41,9 +44,20 @@ jobs:
             ALL_SERVICES="$CONFIG_SERVICES"
           fi
           
+          # Backend에서 변경된 서비스는 제외 (ArgoCD가 자동 재배포하므로)
+          FILTERED_SERVICES=""
+          for service in $ALL_SERVICES; do
+            if ! echo "$BACKEND_CHANGED" | grep -q "^$service$"; then
+              FILTERED_SERVICES="$FILTERED_SERVICES $service"
+            else
+              echo "⏭️ Skipping $service restart (backend changed - ArgoCD will handle deployment)"
+            fi
+          done
+          
           # JSON 배열로 변환
-          CHANGED=$(echo "$ALL_SERVICES" | tr ' ' '\n' | sort | uniq | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          CHANGED=$(echo "$FILTERED_SERVICES" | tr ' ' '\n' | sort | uniq | jq -R -s -c 'split("\n") | map(select(. != ""))')
           echo "services=$CHANGED" >> $GITHUB_OUTPUT
+          echo "🔄 Services to restart: $FILTERED_SERVICES"
 
   restart-services:
     needs: detect-config-changes
@@ -74,7 +88,7 @@ jobs:
       - name: Restart ${{ matrix.service }} service
         run: |
           SERVICE="${{ matrix.service }}"
-          echo "Restarting $SERVICE service..."
+          echo "🔄 Restarting $SERVICE service (config-only change)..."
           
           # 서비스별 deployment 이름과 네임스페이스 매핑
           case $SERVICE in
@@ -99,7 +113,7 @@ jobs:
               NAMESPACE="service-review"
               ;;
             *)
-              echo "Unknown service: $SERVICE"
+              echo "❌ Unknown service: $SERVICE"
               exit 1
               ;;
           esac


### PR DESCRIPTION
## 🚨 문제상황
Backend 코드와 Config 파일이 동시에 변경될 때 서비스가 중복으로 재시작되는 문제

**시나리오**:
1. `backend/gateway/` + `config-repo/gateway.yml` 동시 수정
2. `backend-ci-cd.yaml` 실행 → 새 이미지 빌드 & ArgoCD 재배포
3. `config-ci-cd.yaml` 실행 → gateway 서비스 또 재시작 (중복!)

## 🔧 해결방법
Config CI/CD에서 Backend 변경사항을 감지하여 중복 재시작 방지

## ✅ 변경사항
- **Backend 변경 감지**: `git diff`로 backend 폴더 변경사항 확인
- **스마트 필터링**: Backend 변경된 서비스는 재시작 스킵
- **명확한 로그**: 스킵 이유를 로그로 출력
- **효율성 개선**: 불필요한 kubectl 명령어 실행 방지

## 🎯 개선된 동작
### Before (문제)
```
Backend + Config 동시 변경
→ ArgoCD 재배포 + kubectl restart (중복!)
```

### After (해결)
```
Backend + Config 동시 변경
→ ArgoCD 재배포만 (kubectl restart 스킵)
Config만 변경
→ kubectl restart만 실행
```

## 🧪 테스트 시나리오
1. **Config만 변경**: 정상 재시작
2. **Backend만 변경**: config-ci-cd 실행 안됨
3. **Backend + Config 동시 변경**: 중복 재시작 방지

## 📝 로그 예시
```
⏭️ Skipping gateway restart (backend changed - ArgoCD will handle deployment)
🔄 Services to restart: auth schedule
```