### PR TITLE
Fix: backend-ci-cd matrix strategy error when no backend changes

### DIFF
--- a/.github/workflows/backend-ci-cd.yaml
+++ b/.github/workflows/backend-ci-cd.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.detect.outputs.services }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
       commit_hash: ${{ steps.hash.outputs.commit_hash }}
     steps:
       - name: Checkout
@@ -27,6 +28,15 @@ jobs:
           git fetch origin dev
           CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^backend/' | cut -d '/' -f2 | sort | uniq | jq -R -s -c 'split("\n") | map(select(. != ""))')
           echo "services=$CHANGED" >> $GITHUB_OUTPUT
+          
+          # 변경사항이 있는지 확인
+          if [ "$CHANGED" = "[]" ] || [ "$CHANGED" = "" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "🔍 No backend services changed"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "🔍 Changed backend services: $CHANGED"
+          fi
 
       - name: Get short git commit hash
         id: hash
@@ -35,7 +45,7 @@ jobs:
   build-and-push:
     needs: detect-changes
     runs-on: ubuntu-latest
-    if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}
+    if: ${{ needs.detect-changes.outputs.has_changes == 'true' }}
     strategy:
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
@@ -98,7 +108,7 @@ jobs:
       - detect-changes
       - build-and-push
     runs-on: ubuntu-latest
-    if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}
+    if: ${{ needs.detect-changes.outputs.has_changes == 'true' }}
     steps:
       - name: Download all success artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 🐛 문제 상황

config-repo 파일만 수정했을 때 backend-ci-cd.yaml에서 다음 에러 발생:
```
Matrix vector 'service' does not contain any values
```

## 🔍 원인 분석

1. config-repo만 변경 (backend/ 폴더 변경 없음)
2. detect-changes에서 빈 배열 `[]` 반환
3. Matrix strategy가 빈 배열을 처리하지 못해 에러 발생

## 🛠️ 해결 방법

### 변경사항:
- `has_changes` boolean output 추가
- Matrix strategy 평가 전에 job 조건으로 스킵 처리
- JSON 배열 비교 대신 단순 boolean 비교 사용

### 수정된 로직:
```yaml
# 기존 (문제)
if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}

# 수정 (해결)  
if: ${{ needs.detect-changes.outputs.has_changes == 'true' }}
```
