### PR TITLE
Revert: backend-ci-cd.yaml to original team member's version

### DIFF
--- a/.github/workflows/backend-ci-cd.yaml
+++ b/.github/workflows/backend-ci-cd.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.detect.outputs.services }}
-      has_changes: ${{ steps.detect.outputs.has_changes }}
       commit_hash: ${{ steps.hash.outputs.commit_hash }}
     steps:
       - name: Checkout
@@ -28,15 +27,6 @@ jobs:
           git fetch origin dev
           CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^backend/' | cut -d '/' -f2 | sort | uniq | jq -R -s -c 'split("\n") | map(select(. != ""))')
           echo "services=$CHANGED" >> $GITHUB_OUTPUT
-          
-          # 변경사항이 있는지 확인
-          if [ "$CHANGED" = "[]" ] || [ "$CHANGED" = "" ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "🔍 No backend services changed"
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "🔍 Changed backend services: $CHANGED"
-          fi
 
       - name: Get short git commit hash
         id: hash
@@ -45,7 +35,7 @@ jobs:
   build-and-push:
     needs: detect-changes
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs.has_changes == 'true' }}
+    if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}
     strategy:
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
@@ -108,7 +98,7 @@ jobs:
       - detect-changes
       - build-and-push
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs.has_changes == 'true' }}
+    if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}
     steps:
       - name: Download all success artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 🔄 팀원 원본 코드로 복귀

### 변경 내용
- backend-ci-cd.yaml을 팀원이 원래 작성한 버전으로 되돌림
- 내가 추가한 has_changes 로직 제거
- 원래의 fromJson 조건 체크 방식으로 복원

### 복귀된 코드
```yaml
build-and-push:
  if: ${{ fromJson(needs.detect-changes.outputs.services) != '[]' }}
  strategy:
    matrix:
      service: ${{ fromJson(needs.detect-changes.outputs.services) }}
```

### 테스트 목적
- 팀원 원본 코드가 현재 상황에서 어떻게 동작하는지 확인
- Matrix strategy 에러가 여전히 발생하는지 검증
- config-repo만 변경했을 때의 동작 확인

### 예상 결과
**Backend + Config-repo 동시 변경 상황:**
- backend-ci-cd: 정상 작동 (backend 변경사항 있음)
- config-ci-cd: 중복 재시작 방지 로직 작동

**만약 config-repo만 변경한다면:**
- backend-ci-cd: Matrix strategy 에러 발생 가능성

### 참고
팀원과 상의 후 필요시 다른 해결책 적용 예정