### PR TITLE
fix: auth 서비스 health check 401 에러 해결

### DIFF
--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: "health,info"  # 필요한 엔드포인트만 노출
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## 🚨 문제 상황
Auth 서비스 Pod들이 CrashLoopBackOff 상태로 계속 재시작하는 문제:
- Liveness probe failed: HTTP probe failed with statuscode: 401
- Readiness probe failed: HTTP probe failed with statuscode: 401  
- GitHub Actions에서 서비스 재시작 시 타임아웃 발생

## 🔍 원인 분석
- `application.yml`에서 모든 actuator 엔드포인트 노출 (`include: "*"`)
- Auth 서비스의 Spring Security가 `/actuator/health` 포함 모든 엔드포인트 보호
- Kubernetes health check가 401 Unauthorized로 실패

## 🛠️ 해결 방법
`application.yml`의 actuator 설정 변경:
```yaml
# 변경 전
management:
  endpoints:
    web:
      exposure:
        include: "*"

# 변경 후  
management:
  endpoints:
    web:
      exposure:
        include: "health,info"
```

## ✅ 예상 결과
- Auth 서비스 Pod 정상 시작
- Health check 인증 없이 통과
- GitHub Actions 정상 완료
- 필요한 엔드포인트만 노출하여 보안 향상

## 🧪 검증 과정
- [x] Gateway 서비스는 정상 작동 확인 (Spring Security 없음)
- [x] Auth 서비스만 Spring Security로 인한 문제 확인
- [x] 최소 노출 원칙 적용으로 보안 강화

Auth 서비스 배포 문제 해결 및 전체적인 보안 강화