### PR TITLE
fix: auth 서비스 health check 401 에러 완전 해결

### DIFF
--- a/config-repo/auth.yml
+++ b/config-repo/auth.yml
@@ -5,6 +5,10 @@ spring:
   application:
     name: auth
 
+  security:
+    web:
+      ignore: "/actuator/health"  # health 엔드포인트만 인증 제외
+
   datasource:
     url: "{cipher}da0b4a60517ad7080fa0e371bab0211efb3887a249aadc45a5f7776c2373239f5106ed0b15c00a2e1bdabc63529cb58f8f20708557040969de251fe579d8b62414511e3e7569065a0c7360949c84916e0542e4b28d5e390cbf91a6f846d03ca6bda7070e6f25097a880a61f0f4f95450f08740e7b83c71508d2e1b61cdfad828"
     username: "{cipher}8fe5ea8cbe4b0df0e727b44fa8c26685ce7f3da4582b182f819d6227b39bcfc3"


### PR DESCRIPTION
## 🚨 추가 문제 발견
이전 PR에서 application.yml만 수정했지만 여전히 auth 서비스에서 401 에러 발생

## 🔧 추가 해결책
auth.yml에 직접 Spring Security 설정 추가:
```yaml
spring:
  security:
    web:
      ignore: "/actuator/health"  # health 엔드포인트만 인증 제외
```
