### PR TITLE
fix: SecurityConfig 수정으로 actuator 403 에러 해결

### DIFF
--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
@@ -14,12 +14,13 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/actuator/health", "/actuator/info").permitAll()  // Health check 허용
+                .requestMatchers("/actuator/**").permitAll()  // 모든 actuator 엔드포인트 허용
                 .anyRequest().authenticated()  // 나머지는 인증 필요
             )
-            .csrf(csrf -> csrf.disable())  // CSRF 비활성화 (API 서버이므로)
+            .csrf(csrf -> csrf.disable())  // CSRF 비활성화
             .httpBasic(httpBasic -> httpBasic.disable())  // Basic Auth 비활성화
-            .formLogin(formLogin -> formLogin.disable());  // Form Login 비활성화
+            .formLogin(formLogin -> formLogin.disable())  // Form Login 비활성화
+            .sessionManagement(session -> session.disable());  // Session 비활성화
 
         return http.build();
     }


### PR DESCRIPTION
## 🔄 이전 진전사항
- ✅ **401 → 403 에러로 변경**: SecurityConfig가 적용됨
- ✅ **새 이미지 배포 확인**: `mapzip-dev-ecr-auth:496aa4a`
- ❌ **여전히 403 Forbidden 에러**

## 🛠️ 추가 수정사항
SecurityConfig를 더 명확하게 수정:

```java
// 이전
.requestMatchers("/actuator/health", "/actuator/info").permitAll()

// 수정 후
.requestMatchers("/actuator/**").permitAll()  // 모든 actuator 엔드포인트 허용
.sessionManagement(session -> session.disable())  // 세션 관리 비활성화
```

## ✅ 예상 결과
- **403 → 200 응답 변경**
- **Health check 완전 성공**
- **Pod 2/2 Running 상태**

## 🎯 진행 상황
1. ✅ Spring Boot 3.x 호환 SecurityConfig 추가
2. ✅ 401 에러 해결 (403으로 변경됨)
3. 🔄 403 에러 해결 중 (이번 수정으로 완료 예정)
