### PR TITLE
feat: 백엔드 x-user-id, 프론트 axios 적용

### DIFF
--- a/backend/schedule/src/main/java/com/mapzip/schedule/config/GrpcInterceptorConfig.java
+++ b/backend/schedule/src/main/java/com/mapzip/schedule/config/GrpcInterceptorConfig.java
@@ -1,0 +1,36 @@
+package com.mapzip.schedule.config;
+
+import io.grpc.*;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class GrpcInterceptorConfig {
+
+    // gRPC 컨텍스트에 사용자 ID를 저장하기 위한 Key
+    public static final Context.Key<String> USER_ID_CONTEXT_KEY = Context.key("userId");
+
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor userIdInterceptor() {
+        return new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+                // Metadata에서 "x-user-id" 헤더 값을 추출
+                String userId = headers.get(Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER));
+
+                if (userId != null) {
+                    log.info("Extracted userId from header: {}", userId);
+                    // userId가 존재하면 Context에 저장
+                    Context context = Context.current().withValue(USER_ID_CONTEXT_KEY, userId);
+                    return Contexts.interceptCall(context, call, headers, next);
+                } else {
+                    log.warn("x-user-id header not found.");
+                    // userId가 없으면 그냥 다음 인터셉터/서비스로 체인 계속
+                    return next.startCall(call, headers);
+                }
+            }
+        };
+    }
+}

--- a/backend/schedule/src/main/java/com/mapzip/schedule/service/ScheduleGrpcService.java
+++ b/backend/schedule/src/main/java/com/mapzip/schedule/service/ScheduleGrpcService.java
@@ -1,5 +1,6 @@
 package com.mapzip.schedule.service;
 
+import com.mapzip.schedule.config.GrpcInterceptorConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mapzip.schedule.entity.MealTimeSlot;
 import com.mapzip.schedule.entity.Schedule;
@@ -79,7 +80,8 @@ public class ScheduleGrpcService extends ScheduleServiceGrpc.ScheduleServiceImpl
             Schedule schedule = scheduleRepository.findById(request.getScheduleId())
                     .orElseThrow(() -> Status.NOT_FOUND.withDescription("수정할 스케줄을 찾을 수 없습니다: " + request.getScheduleId()).asRuntimeException());
 
-            if (!schedule.getUserId().equals(request.getUserId())) {
+            String userId = GrpcInterceptorConfig.USER_ID_CONTEXT_KEY.get();
+            if (!schedule.getUserId().equals(userId)) {
                 throw Status.PERMISSION_DENIED.withDescription("이 스케줄을 수정할 권한이 없습니다.").asRuntimeException();
             }
 
@@ -143,7 +145,8 @@ public class ScheduleGrpcService extends ScheduleServiceGrpc.ScheduleServiceImpl
             Schedule schedule = scheduleRepository.findById(request.getScheduleId())
                     .orElseThrow(() -> new IllegalArgumentException("스케줄을 찾을 수 없습니다."));
 
-            if (!schedule.getUserId().equals(request.getUserId())) {
+            String userId = GrpcInterceptorConfig.USER_ID_CONTEXT_KEY.get();
+            if (!schedule.getUserId().equals(userId)) {
                 responseObserver.onError(io.grpc.Status.PERMISSION_DENIED
                         .withDescription("해당 스케줄에 접근할 권한이 없습니다.")
                         .asRuntimeException());
@@ -178,7 +181,8 @@ public class ScheduleGrpcService extends ScheduleServiceGrpc.ScheduleServiceImpl
             Schedule schedule = scheduleRepository.findById(request.getScheduleId())
                     .orElseThrow(() -> Status.NOT_FOUND.withDescription("스케줄을 찾을 수 없습니다: " + request.getScheduleId()).asRuntimeException());
 
-            if (!schedule.getUserId().equals(request.getUserId())) {
+            String userId = GrpcInterceptorConfig.USER_ID_CONTEXT_KEY.get();
+            if (!schedule.getUserId().equals(userId)) {
                 throw Status.PERMISSION_DENIED.withDescription("이 스케줄을 삭제할 권한이 없습니다.").asRuntimeException();
             }
 

--- a/frontend/lib/interceptor.ts
+++ b/frontend/lib/interceptor.ts
@@ -5,19 +5,6 @@ const api = axios.create({
     withCredentials: true,
 })
 
-// 요청 인터셉터 (x-user-id 헤더 추가)
-api.interceptors.request.use(
-    (config) => {
-        // 임시로 사용자 ID를 헤더에 추가합니다.
-        // TODO: 실제 로그인 구현 시, 이 부분은 삭제하거나 실제 사용자 정보로 대체해야 합니다.
-        config.headers['x-user-id'] = 'test-user-123';
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
 let isRefreshing = false
 
 type Subscriber = {

--- a/frontend/lib/interceptor.ts
+++ b/frontend/lib/interceptor.ts
@@ -5,6 +5,19 @@ const api = axios.create({
     withCredentials: true,
 })
 
+// 요청 인터셉터 (x-user-id 헤더 추가)
+api.interceptors.request.use(
+    (config) => {
+        // 임시로 사용자 ID를 헤더에 추가합니다.
+        // TODO: 실제 로그인 구현 시, 이 부분은 삭제하거나 실제 사용자 정보로 대체해야 합니다.
+        config.headers['x-user-id'] = 'test-user-123';
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
+
 let isRefreshing = false
 
 type Subscriber = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-toastify": "^4.1.0",
+    "axios": "^1.7.2",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5",


### PR DESCRIPTION
## ✅ 요약
백엔드 x-user-id, 프론트 axios 적용

## 🧩 변경 내용
frontend\lib\interceptor.ts: 임시 x-user-id 헤더
frontend\services\api.ts: 스케줄api axios 적용
backend\schedule\src\main\java\com\mapzip\schedule\config\GrpcInterceptorConfig.java:
x-user-id를 받아 쓰기 위해 추가된 파일
backend\schedule\src\main\java\com\mapzip\schedule\service\ScheduleGrpcService.java
x-user-id를 gRPC가 받아 쓰도록 수정
- 추가된 기능/수정된 기능 요약

## 🔍 확인 필요사항 (선택)
테스트가 필요한 부분이나, 다음 작업과 연관되는 부분 정리

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
