### PR TITLE
fix: Add Istio health check path to Auth SecurityConfig

### DIFF
--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/actuator/**").permitAll()
+                .requestMatchers("/actuator/**", "/app-health/**").permitAll()
                 .anyRequest().authenticated()
             )
             .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 🐛 문제 해결

### 현재 문제
- Auth 서비스 Pod가 `1/2 Running` 상태에서 멈춤
- Istio liveness/readiness probe에서 **403 Forbidden** 에러 발생
- `kubectl describe pod`에서 확인된 에러:
  - `Readiness probe failed: HTTP probe failed with statuscode: 403`
  - `Liveness probe failed: HTTP probe failed with statuscode: 403`

### 원인 분석
Istio가 다음 경로로 health check를 수행:
- `http://:15020/app-health/auth-service-container/livez`
- `http://:15020/app-health/auth-service-container/readyz`

기존 SecurityConfig에서는 `/actuator/**`만 허용했지만, Istio의 `/app-health/**` 경로는 허용하지 않음

### 해결책
```java
// 이전
.requestMatchers("/actuator/**").permitAll()

// 수정 후  
.requestMatchers("/actuator/**", "/app-health/**").permitAll()
```

### 예상 결과
- ✅ Istio health check 성공
- ✅ Pod 상태: `1/2 Running` → `2/2 Running`
- ✅ Auth 서비스 완전 정상화

## 🔧 기술적 세부사항
- **Istio Sidecar**: 모든 Pod에 자동 주입되어 health check 수행
- **Health Check 경로**: Istio가 애플리케이션별로 생성하는 특별한 경로
- **Spring Security**: 명시적으로 허용하지 않은 경로는 기본적으로 차단

## 📝 관련 이슈
- Auth 서비스 403 에러 해결
- Istio 환경에서의 Spring Security 설정 최적화