### PR TITLE
fix: Resolve Auth service 403 Forbidden error (temporary fix)

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -55,6 +55,18 @@
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 
+        <!-- Actuator for health checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Micrometer Prometheus for metrics -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
@@ -15,8 +15,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/actuator/**", "/app-health/**").permitAll()
-                .anyRequest().authenticated()
+                .anyRequest().permitAll()  // 임시로 모든 경로 허용
             )
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)

--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
@@ -15,7 +15,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()  // 임시로 모든 경로 허용
+                .requestMatchers("/actuator/**").permitAll()
+                .anyRequest().authenticated()
             )
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 🚨 긴급 수정: Auth 서비스 403 에러 해결

### 현재 상황
- Auth 서비스 Pod가 계속 `1/2 Running` 상태
- Istio health check에서 **403 Forbidden** 에러 지속 발생
- 여러 차례 SecurityConfig 수정했지만 문제 지속

### 시도한 해결책들
1. ✅ `/actuator/**` 경로 허용
2. ✅ `/app-health/**` 경로 추가 허용
3. 🔄 **현재**: 모든 요청 임시 허용 (디버깅용)

### 임시 해결책 (현재 적용)
```java
.authorizeHttpRequests(auth -> auth
    .anyRequest().permitAll()  // 임시로 모든 경로 허용
)
```

### 목적
- **403 에러 원인 파악**: SecurityConfig 문제인지 다른 원인인지 확인
- **서비스 정상화**: Auth Pod를 `2/2 Running` 상태로 만들기

