### PR TITLE
🔧 Fix recommend service build compatibility

### DIFF
--- a/backend/recommend/pom.xml
+++ b/backend/recommend/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.3</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.team4</groupId>


### PR DESCRIPTION
## 🔧 Recommend 서비스 빌드 호환성 수정

### 변경사항
- Spring Boot 버전: 3.5.4 → 3.5.3 (다른 서비스와 동일)

### 문제해결
- GitHub Actions CI/CD 빌드 실패 해결
- 서비스 간 버전 일관성 확보

### 영향
- Recommend 서비스 Docker 이미지 빌드 성공
- ECR 푸시 및 배포 정상화