### PR TITLE
fix: Remove duplicate spring key in recommend.yml

### DIFF
--- a/config-repo/recommend.yml
+++ b/config-repo/recommend.yml
@@ -43,8 +43,7 @@ eureka:
   client:
     enabled: false
 
-# Kafka 
-spring:
+  # Kafka 
   kafka:
     bootstrap-servers: ${MSK_BOOTSTRAP_SERVERS}
     producer:


### PR DESCRIPTION
Fix YAML parsing error in Config Server

- Remove duplicate spring key in recommend.yml
- Merge Kafka config under existing spring section
- Resolves 500 error when fetching recommend service config