### PR TITLE
fix: Add Actuator dependencies for recommend service health checks

### DIFF
--- a/backend/recommend/pom.xml
+++ b/backend/recommend/pom.xml
@@ -184,6 +184,18 @@
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>
     </dependency>
+
+    <!-- Actuator -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- Micrometer Prometheus Registry -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
recommend 서비스 health check 실패 해결을 위해 누락된 Actuator 의존성 추가

- spring-boot-starter-actuator
- micrometer-registry-prometheus