### PR TITLE
fix:콜백 요청이 성공했을 경우에만 세션스토리지 저장

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -36,10 +36,11 @@ function KakaoCallbackInner() {
         }
 
         // 최초 콜백 처리
-        sessionStorage.setItem('kakaoLoginDone', 'true');
-
         api.post(`/auth/kakao/callback?code=${code}`)
-            .then(() => router.replace('/'))
+            .then(() => {
+                sessionStorage.setItem('kakaoLoginDone', 'true');
+                router.replace('/')
+            })
             .catch(() => router.replace('/auth/login?error=callback_failed'));
     }, [router, searchParams]);
 


### PR DESCRIPTION
## ✅ 요약
카카오 콜백 로직에서 최초 콜백 처리가 성공했을 경우에만 세션스토리지에 'kakaoLoginDone'을 저장하도록 수정했습니다.
