### PR TITLE
fix: 리뷰서비스pod 복구설정

### DIFF
--- a/config-repo/review.yml
+++ b/config-repo/review.yml
@@ -26,14 +26,14 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}  # AUTH 비활성화됨
       database: ${REDIS_DATABASE:0}
-      timeout: ${REDIS_TIMEOUT:3000ms}
+      timeout: ${REDIS_TIMEOUT:1000ms}
       ssl: false
       lettuce:
         pool:
-          max-active: ${REDIS_POOL_MAX_ACTIVE:16}
-          max-idle: ${REDIS_POOL_MAX_IDLE:16}
-          min-idle: ${REDIS_POOL_MIN_IDLE:4}
-          max-wait: ${REDIS_POOL_MAX_WAIT:3000ms}
+          max-active: ${REDIS_POOL_MAX_ACTIVE:8}
+          max-idle: ${REDIS_POOL_MAX_IDLE:8}
+          min-idle: ${REDIS_POOL_MIN_IDLE:2}
+          max-wait: ${REDIS_POOL_MAX_WAIT:1000ms}
           
   # 캐시 설정
   cache:


### PR DESCRIPTION
## ✅ 요약
 - Redis 연결 타임아웃 최적화 (3초 → 1초)
 - 헬스체크 설정 관대하게 조정 (failureThreshold 3→5)
 - Pod 재시작 어노테이션 추가
 - 리소스 풀 크기 조정 (16→8)

