### PR TITLE
fix: 인증서버 jwt인코딩 서명 HSA256  알고리즘으로 수정

### DIFF
--- a/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
+++ b/backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
@@ -1,8 +1,12 @@
 package com.mapzip.auth.auth_service.config;
 
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -80,6 +84,15 @@ public class SecurityConfig {
         OAuth2RefreshTokenGenerator refreshTokenGenerator = new OAuth2RefreshTokenGenerator();
         JwtGenerator jwtGenerator = new JwtGenerator(jwtEncoder);
         return new DelegatingOAuth2TokenGenerator(jwtGenerator, accessTokenGenerator, refreshTokenGenerator);
+    }
+
+    @Bean
+    public JWKSource<SecurityContext> jwkSource(@Value("${jwt.secret}") String jwtSecret) {
+        OctetSequenceKey hmacKey = new OctetSequenceKey.Builder(jwtSecret.getBytes())
+                .keyID("auth-hmac-key")
+                .build();
+        JWKSet jwkSet = new JWKSet(hmacKey);
+        return new ImmutableJWKSet<>(jwkSet);
     }
 
     @Bean


### PR DESCRIPTION
## ✅ 요약
인증서버 jwt인코딩 서명 HSA256  알고리즘으로 수정

## 🧩 변경 내용
- backend/auth/src/main/java/com/mapzip/auth/auth_service/config/SecurityConfig.java
- 백엔드 인증서버와 게이트웨이서버의 jwt토큰 생성과 검증 알고리즘이 맞지않아 HSA256알고리즘으로 통일했습니다.


