### PR TITLE
fix: gateway 서버 복수의 쿼리파라미터 파싱에 문제없게 XSS 필터링

### DIFF
--- a/backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java
+++ b/backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java
@@ -52,8 +52,24 @@ public class XssProtectionFilter extends AbstractGatewayFilterFactory<XssProtect
 
                 if (query != null) {
                     log.info("[XSS Filter] GET Query - Original: {}", query);
-                    String sanitizedQuery = sanitizeXss(query);
+
+                    // 안전하게 각 파라미터별로 sanitize
+                    String sanitizedQuery = Arrays.stream(query.split("&"))
+                            .map(param -> {
+                                String[] kv = param.split("=", 2);
+                                if (kv.length == 2) {
+                                    String key = kv[0];
+                                    String value = URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
+                                    String sanitizedValue = sanitizeXss(value);
+                                    return URLEncoder.encode(key, StandardCharsets.UTF_8) + "=" +
+                                            URLEncoder.encode(sanitizedValue, StandardCharsets.UTF_8);
+                                }
+                                return param;
+                            })
+                            .collect(Collectors.joining("&"));
+
                     log.info("[XSS Filter] GET Query - Sanitized: {}", sanitizedQuery);
+
                     URI newUri = UriComponentsBuilder.fromUri(originalUri)
                             .replaceQuery(sanitizedQuery)
                             .build()


### PR DESCRIPTION
## ✅ 요약
복수의 쿼리파라미터 파싱에 문제없게 XSS 필터링

## 🧩 변경 내용
- backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java
  - 기존 복수 쿼리파라미터를 하나의 쿼리파라미터로 XSS필터링 처리하여 각 서버에서 파싱이 어려워짐
  - 복수파라미터를 분리해서 필터링하고 파싱에 문제 없도록 수정했습니다.

