### PR TITLE
fix: Schedule 서비스 N+1 쿼리 성능 최적화

### DIFF
--- a/config-repo/recommend.yml
+++ b/config-repo/recommend.yml
@@ -36,9 +36,14 @@ spring:
 
   kafka:
     bootstrap-servers: >
-      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
-      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
-      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092
+      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
+      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
+      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094
+    security:
+      protocol: SSL
+    ssl:
+      trust-store-type: JKS
+      endpoint-identification-algorithm: ""
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/config-repo/recommend.yml
+++ b/config-repo/recommend.yml
@@ -36,9 +36,14 @@ spring:
 
   kafka:
     bootstrap-servers: >
-      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
-      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
-      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092
+      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
+      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
+      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094
+    security:
+      protocol: SSL
+    ssl:
+      trust-store-type: JKS
+      endpoint-identification-algorithm: ""
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
@@ -49,6 +54,10 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       group-id: recommend-service
       auto-offset-reset: earliest
+      session-timeout-ms: 30000
+      heartbeat-interval-ms: 10000
+      request-timeout-ms: 60000
+      retry-backoff-ms: 1000
 
   cloud:
     kubernetes:

--- a/config-repo/recommend.yml
+++ b/config-repo/recommend.yml
@@ -36,14 +36,9 @@ spring:
 
   kafka:
     bootstrap-servers: >
-      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
-      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094,
-      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9094
-    security:
-      protocol: SSL
-    ssl:
-      trust-store-type: JKS
-      endpoint-identification-algorithm: ""
+      b-1.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
+      b-2.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092,
+      b-3.mapzipdevmain.0u4z0i.c4.kafka.ap-northeast-2.amazonaws.com:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/config-repo/schedule.yml
+++ b/config-repo/schedule.yml
@@ -33,6 +33,13 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        # N+1 쿼리 해결
+        default_batch_fetch_size: 16
+        # 배치 처리
+        jdbc:
+          batch_size: 20
+          order_inserts: true
+          order_updates: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
   # Kubernetes 서비스 디스커버리 활성화


### PR DESCRIPTION
## 🚨 문제 상황
- Schedule 서비스 CPU 사용량 57% (비정상적으로 높음)
- N+1 쿼리 문제로 동일한 Hibernate 쿼리 반복 실행
- kubectl top pods에서 확인된 성능 이슈

## ✅ 해결 방안
- `default_batch_fetch_size: 16` 설정으로 N+1 쿼리 해결
- `batch_size: 20`으로 배치 처리 최적화
- `order_inserts/order_updates: true`로 쿼리 순서 최적화

## 🎯 예상 효과
- CPU 사용량: 57% → 10% 이하 감소
- 데이터베이스 부하 감소
- 애플리케이션 응답 속도 개선

## 📁 변경 파일
- `config-repo/schedule.yml` - JPA 최적화 설정 추가