### PR TITLE
fix:ReviewClientService.java 수정

### DIFF
--- a/backend/recommend/src/main/java/com/mapzip/recommend/service/ReviewClientService.java
+++ b/backend/recommend/src/main/java/com/mapzip/recommend/service/ReviewClientService.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mapzip.recommend.dto.ReviewStatsDto;
 import com.mapzip.recommend.entity.RecommendationSelectionEntity;
@@ -14,9 +12,13 @@ import com.mapzip.review.grpc.ReviewProto.GetReviewSummaryRequest;
 import com.mapzip.review.grpc.ReviewProto.GetReviewSummaryResponse;
 import com.mapzip.review.grpc.ReviewProto.RestaurantReviewSummary;
 import com.mapzip.review.grpc.ReviewServiceGrpc;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReviewClientService {
@@ -24,41 +26,59 @@ public class ReviewClientService {
     private final ReviewServiceGrpc.ReviewServiceBlockingStub reviewStub;
 
     public void storePlacesForReview(String userId, List<RecommendationSelectionEntity> selections) {
-        List<com.mapzip.review.grpc.ReviewProto.ReviewPlaceInfo> placeInfos = selections.stream()
-                .map(selection -> com.mapzip.review.grpc.ReviewProto.ReviewPlaceInfo.newBuilder()
-                        .setId(selection.getPlaceId())
-                        .setPlaceName(selection.getPlaceName())
-                        .setAddressName(selection.getAddressName())
-                        .setPlaceUrl(selection.getPlaceUrl())
-                        .setScheduledTime(selection.getScheduledTime())
-                        .build())
-                .collect(Collectors.toList());
+        try {
+            List<com.mapzip.review.grpc.ReviewProto.ReviewPlaceInfo> placeInfos = selections.stream()
+                    .map(selection -> com.mapzip.review.grpc.ReviewProto.ReviewPlaceInfo.newBuilder()
+                            .setId(selection.getPlaceId())
+                            .setPlaceName(selection.getPlaceName())
+                            .setAddressName(selection.getAddressName())
+                            .setPlaceUrl(selection.getPlaceUrl())
+                            .setScheduledTime(selection.getScheduledTime())
+                            .build())
+                    .collect(Collectors.toList());
 
-        com.mapzip.review.grpc.ReviewProto.StorePlacesForReviewRequest request = com.mapzip.review.grpc.ReviewProto.StorePlacesForReviewRequest.newBuilder()
-                .setUserId(userId)
-                .addAllPlaces(placeInfos)
-                .build();
+            com.mapzip.review.grpc.ReviewProto.StorePlacesForReviewRequest request = com.mapzip.review.grpc.ReviewProto.StorePlacesForReviewRequest.newBuilder()
+                    .setUserId(userId)
+                    .addAllPlaces(placeInfos)
+                    .build();
 
-        reviewStub.storePlacesForReview(request);
+            // x-user-id 헤더 추가
+            io.grpc.Metadata headers = new io.grpc.Metadata();
+            headers.put(io.grpc.Metadata.Key.of("x-user-id", io.grpc.Metadata.ASCII_STRING_MARSHALLER), userId);
+            
+            reviewStub.withInterceptors(io.grpc.stub.MetadataUtils.newAttachHeadersInterceptor(headers))
+                    .storePlacesForReview(request);
+            
+            log.info("Successfully stored {} places for review for user: {}", placeInfos.size(), userId);
+        } catch (Exception e) {
+            log.error("Failed to store places for review for user: {}", userId, e);
+            throw new RuntimeException("리뷰 서버 연동 실패: " + e.getMessage(), e);
+        }
     }
 
     public ReviewStatsDto getRestaurantStats(String restaurant_id) {
-    	GetReviewSummaryRequest request = GetReviewSummaryRequest.newBuilder()
-    			.addAllRestaurantIds(Arrays.asList(restaurant_id))
-                .build();
+        try {
+            GetReviewSummaryRequest request = GetReviewSummaryRequest.newBuilder()
+                    .addAllRestaurantIds(Arrays.asList(restaurant_id))
+                    .build();
 
-    	GetReviewSummaryResponse response = reviewStub.getReviewSummaryForRecommendation(request);
-    	
-    	//response를 reviewStatsDto로 변경
-    	RestaurantReviewSummary summary = response.getSummariesList().get(0);
-    	double averageRating = summary.getAverageRating();
-    	String joinedReviews = String.join(" | ", summary.getTopReviewsList());
-    	
-        return new ReviewStatsDto(
-                averageRating,
-                joinedReviews
-        );
-        //목데이터 
-//    	return new ReviewStatsDto(4.2, "음식도 맛있고 분위기도 좋아요!");
+            GetReviewSummaryResponse response = reviewStub.getReviewSummaryForRecommendation(request);
+            
+            //response를 reviewStatsDto로 변경
+            if (response.getSummariesCount() > 0) {
+                RestaurantReviewSummary summary = response.getSummariesList().get(0);
+                double averageRating = summary.getAverageRating();
+                String joinedReviews = String.join(" | ", summary.getTopReviewsList());
+                
+                return new ReviewStatsDto(averageRating, joinedReviews);
+            } else {
+                log.warn("No review summary found for restaurant: {}", restaurant_id);
+                return new ReviewStatsDto(0.0, "");
+            }
+        } catch (Exception e) {
+            log.error("Failed to get restaurant stats for restaurant: {}", restaurant_id, e);
+            // 목데이터로 fallback
+            return new ReviewStatsDto(4.2, "음식도 맛있고 분위기도 좋아요!");
+        }
     }
 }


### PR DESCRIPTION
## ✅ 요약
천 서버에서 직접 x-user-id 헤더를 설정하여 전달

## 🧩 변경 내용
- storePlacesForReview() 메서드에 x-user-id 헤더 추가
- getRestaurantStats() 메서드도 에러 처리 개선

## 📝 메모 
- 프론트엔드에서 "입력완료" 클릭 → 추천서버 /recommend/submit 호출 → 리뷰서버 storePlacesForReview gRPC 호출 시 x-user-id 헤더 누락으로 인증 실패
