### PR TITLE
fix: multipart formdata XSS 필터링 원상복구

### DIFF
--- a/backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java
+++ b/backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java
@@ -85,6 +85,14 @@ public class XssProtectionFilter extends AbstractGatewayFilterFactory<XssProtect
                 return chain.filter(exchange);
             }
 
+
+            // multipart/form-data 요청은 XSS 필터링 완전히 건너뛰기
+            MediaType contentType = request.getHeaders().getContentType();
+            if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
+                log.debug("[XSS Filter] Bypassing multipart/form-data request completely");
+                return chain.filter(exchange);
+            }
+
             // POST/PUT 요청은 body 필터링
             ServerHttpRequestDecorator decorator = new ServerHttpRequestDecorator(request) {
                 @Override
@@ -134,7 +142,8 @@ public class XssProtectionFilter extends AbstractGatewayFilterFactory<XssProtect
         } else if (MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(contentType)) {
             return sanitizeFormBody(body);
         } else if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
-            return sanitizeMultipartBody(body, contentType);
+            log.debug("[XSS Filter] Skipping multipart/form-data content type");
+            return body;
         }
 
         return sanitizeXss(body);
@@ -175,62 +184,6 @@ public class XssProtectionFilter extends AbstractGatewayFilterFactory<XssProtect
         }
     }
 
-    private String sanitizeMultipartBody(String body, MediaType contentType) {
-        try {
-            log.debug("[XSS Filter] Processing multipart body");
-            String boundary = contentType.getParameter("boundary");
-            if (boundary == null) {
-                log.warn("[XSS Filter] No boundary found in multipart content");
-                return body;
-            }
-            log.debug("[XSS Filter] Boundary: {}", boundary);
-
-            String[] parts = body.split("--" + boundary);
-            log.debug("[XSS Filter] Found {} parts in multipart body", parts.length);
-            StringBuilder result = new StringBuilder();
-
-            for (int i = 0; i < parts.length; i++) {
-                String part = parts[i];
-                log.debug("[XSS Filter] Processing part {}: length={}", i, part.length());
-                
-                if (part.trim().isEmpty() || part.equals("--")) {
-                    result.append("--").append(boundary).append(part);
-                    continue;
-                }
-
-                // 헤더와 바디 분리
-                String[] headerAndBody = part.split("\r\n\r\n", 2);
-                if (headerAndBody.length == 2) {
-                    String headers = headerAndBody[0];
-                    String partBody = headerAndBody[1];
-                    log.debug("[XSS Filter] Part {} headers: {}", i, headers.replaceAll("\r\n", " | "));
-
-                    // Content-Type이 text인 경우만 sanitize
-                    if (headers.contains("Content-Type:") &&
-                            !headers.toLowerCase().contains("content-type: text")) {
-                        log.debug("[XSS Filter] Part {} is binary data, skipping sanitization", i);
-                        // 바이너리 데이터는 그대로 유지
-                        result.append("--").append(boundary).append(part);
-                    } else {
-                        log.debug("[XSS Filter] Part {} is text data, applying sanitization", i);
-                        // 텍스트 필드는 sanitize
-                        String sanitizedBody = sanitizeXss(partBody);
-                        log.debug("[XSS Filter] Part {} body: '{}' -> '{}'", i, partBody.trim(), sanitizedBody.trim());
-                        result.append("--").append(boundary).append(headers)
-                                .append("\r\n\r\n").append(sanitizedBody);
-                    }
-                } else {
-                    log.debug("[XSS Filter] Part {} has no body separator, keeping as-is", i);
-                    result.append("--").append(boundary).append(part);
-                }
-            }
-
-            return result.toString();
-        } catch (Exception e) {
-            log.warn("[XSS Filter] Multipart parsing failed: {}", e.getMessage());
-            return body; // multipart는 실패시 원본 유지 (바이너리 손상 방지)
-        }
-    }
 
     private JsonNode sanitizeJsonNode(JsonNode node) {
         if (node.isTextual()) {


### PR DESCRIPTION
## ✅ 요약
multipart formdata XSS 필터링 수정을 원상복구

## 변경 내용
- backend/gateway/src/main/java/mapzip/gateway/filter/XssProtectionFilter.java 
- multipart 를 직접 해체하고 데이터 정제 후 조립하여 반환해야 하는데 파싱 및 패턴 처리에 고려할 케이스가 많아 Gateway에서는 통과

## 확인 필요사항 (선택)
- Controller/Service 레벨에서 바인딩된 문자열에만 sanitize 적용
