### PR TITLE
fix: 리뷰서버 ,추천서버 연동수정

### DIFF
--- a/backend/recommend/src/main/java/com/mapzip/recommend/grpc/RecommendServiceImpl.java
+++ b/backend/recommend/src/main/java/com/mapzip/recommend/grpc/RecommendServiceImpl.java
@@ -127,7 +127,13 @@ public class RecommendServiceImpl extends RecommendServiceGrpc.RecommendServiceI
 		}
 
 		// 리뷰 서비스에 미작성 리뷰로 저장 요청
-		reviewClientService.storePlacesForReview(userId, savedEntities);
+		try {
+			reviewClientService.storePlacesForReview(userId, savedEntities);
+			log.info("Successfully stored places for review for user: {}", userId);
+		} catch (Exception e) {
+			log.error("Failed to store places for review, but continuing with response for user: {}", userId, e);
+			// 리뷰 서버 연동 실패해도 추천 저장은 성공으로 처리
+		}
 
 		SubmitResponse response = SubmitResponse.newBuilder().setStatus("OK").setMessage("✅ 선택된 식당들이 성공적으로 저장되었습니다.").build();
 

--- a/backend/recommend/src/main/java/com/mapzip/recommend/service/ReviewClientService.java
+++ b/backend/recommend/src/main/java/com/mapzip/recommend/service/ReviewClientService.java
@@ -52,7 +52,8 @@ public class ReviewClientService {
             log.info("Successfully stored {} places for review for user: {}", placeInfos.size(), userId);
         } catch (Exception e) {
             log.error("Failed to store places for review for user: {}", userId, e);
-            throw new RuntimeException("리뷰 서버 연동 실패: " + e.getMessage(), e);
+            // RuntimeException 대신 로그만 남기고 계속 진행
+            // throw new RuntimeException("리뷰 서버 연동 실패: " + e.getMessage(), e);
         }
     }
 

--- a/backend/review/src/main/java/com/mapzip/review/grpc/GrpcHeaderInterceptor.java
+++ b/backend/review/src/main/java/com/mapzip/review/grpc/GrpcHeaderInterceptor.java
@@ -23,19 +23,35 @@ public class GrpcHeaderInterceptor implements ServerInterceptor {
             Metadata headers,
             ServerCallHandler<ReqT, RespT> next) {
 
+        String methodName = call.getMethodDescriptor().getFullMethodName();
+        
+        // 내부 서비스 간 호출은 인증 우회
+        if (isInternalServiceCall(methodName)) {
+            logger.info("Internal service call detected, skipping authentication: {}", methodName);
+            
+            // 내부 호출에서도 x-user-id가 있으면 Context에 저장
+            String userId = headers.get(Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER));
+            if (userId != null && !userId.isEmpty()) {
+                Context context = Context.current().withValue(USER_ID_CONTEXT_KEY, userId);
+                return Contexts.interceptCall(context, call, headers, next);
+            }
+            
+            // x-user-id가 없어도 통과
+            return next.startCall(call, headers);
+        }
+
         // Gateway에서 HTTP 헤더로 전달된 x-user-id 추출
         String userId = headers.get(Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER));
         
         if (userId == null || userId.isEmpty()) {
-            logger.warn("Authentication failed - Missing x-user-id. Method: {}", 
-                      call.getMethodDescriptor().getFullMethodName());
+            logger.warn("Authentication failed - Missing x-user-id. Method: {}", methodName);
             call.close(Status.UNAUTHENTICATED.withDescription("Authentication required"), headers);
             return new ServerCall.Listener<ReqT>() {};
         }
         
         if (!isValidUserId(userId)) {
             logger.warn("Authentication failed - Invalid x-user-id format: {}. Method: {}", 
-                      userId, call.getMethodDescriptor().getFullMethodName());
+                      userId, methodName);
             call.close(Status.UNAUTHENTICATED.withDescription("Invalid user ID format"), headers);
             return new ServerCall.Listener<ReqT>() {};
         }
@@ -57,6 +73,16 @@ public class GrpcHeaderInterceptor implements ServerInterceptor {
         // Context에 사용자 ID 저장
         Context context = Context.current().withValue(USER_ID_CONTEXT_KEY, userId);
         return Contexts.interceptCall(context, call, headers, next);
+    }
+    
+    /**
+     * 내부 서비스 간 호출인지 확인
+     * 특정 gRPC 메서드는 인증을 우회
+     */
+    private boolean isInternalServiceCall(String methodName) {
+        return methodName.contains("StorePlacesForReview") ||
+               methodName.contains("GetReviewSummaryForRecommendation") ||
+               methodName.contains("GetReviewsForRecommendation");
     }
     
     /**


### PR DESCRIPTION
## ✅ 요약
RecommendServiceImpl: 리뷰서버 연동 실패 시에도 추천 저장은 성공으로 처리
ReviewClientService: gRPC 호출 시 x-user-id 헤더 추가
GrpcHeaderInterceptor 수정

## 🧩 변경 내용
- isInternalServiceCall() 메서드 추가
- 내부 gRPC 호출(StorePlacesForReview, GetReviewSummaryForRecommendation 등)에 대해서는 인증 생략
- x-user-id 헤더가 있으면 Context에 저장, 없어도 통과

