### PR TITLE
fix: redis에서 JavaTimeModule 등록

### DIFF
--- a/backend/review/pom.xml
+++ b/backend/review/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Jackson JSR310 (Java 8 Time) support -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
## ✅ 요약
redis에서 JavaTimeModule 등록

## 🧩 변경 내용
- CacheConfig.java에서 이미 JavaTimeModule을 등록했지만, 캐시 매니저에서 사용하는 GenericJackson2JsonRedisSerializer에는 이 설정이 적용되지 않아 에러발생
- pom.xml에 의존성 추가

