### PR TITLE
fix: MSK 메시지 크기 제한을 5MB로 증가 및 애플리케이션 Kafka 설정 업데이트

### DIFF
--- a/config-repo/recommend.yml
+++ b/config-repo/recommend.yml
@@ -55,11 +55,13 @@ spring:
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
       acks: all
       retries: 3
+      max-request-size: 5242880 
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       group-id: recommend-service
       auto-offset-reset: earliest
+      max-partition-fetch-bytes: 5242880
 
   cloud:
     kubernetes:


### PR DESCRIPTION
## ✅ 요약
Kafka 메시지 크기 제한 오류

## 🧩 변경 내용
- Kafka Producer `max-request-size`: 5MB 설정
- Kafka Consumer `max-partition-fetch-bytes`: 5MB 설정

## 🔍 확인 필요사항 (선택)
- 인프라 설정 완료 후에 앱 설정 pr 머지 및 배포

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
