### PR TITLE
fix:google api key 시크릿 볼륨 마운트 방식으로 수정

### DIFF
--- a/config-repo/review.yml
+++ b/config-repo/review.yml
@@ -76,9 +76,9 @@ google:
   cloud:
     vision:
       # 서비스 계정 키 JSON 전체를 암호화하여 저장
-      api-key: '{cipher}798530495fe60a86b7bd81222828d6e3a13431e512e4c5a66f521bb86f202aee'
+      # api-key: '{cipher}798530495fe60a86b7bd81222828d6e3a13431e512e4c5a66f521bb86f202aee'
       # 이거아니면 또는 Kubernetes Secret을 통한 파일 경로 방식도 가능
-      # credentials-path: ${GOOGLE_APPLICATION_CREDENTIALS:/var/secrets/google/service-account-key.json}
+      credentials-path: ${GOOGLE_APPLICATION_CREDENTIALS:/var/secrets/google-api.json}
 
 # Eureka 비활성화
 eureka:


### PR DESCRIPTION
## ✅ 요약
google api key 시크릿 볼륨 마운트 방식으로 수정

## 🧩 변경 내용
- config-repo/review.yml 에서 config server 암호화 방식이 아닌 시크릿 경로 방식으로 수정합니다.

## 메모
- config server 암호화는 긴 json 파일을 암복호화 하는데 최적화되어 있지 않습니다.
