### PR TITLE
fix: ocr 방문날짜,신뢰도,작성리뷰목록수정

### DIFF
--- a/backend/review/src/main/java/com/mapzip/review/service/OcrService.java
+++ b/backend/review/src/main/java/com/mapzip/review/service/OcrService.java
@@ -140,6 +140,7 @@ public class OcrService {
         // 방문 날짜 추출
         String visitDate = extractVisitDate(text);
         result.setVisitDate(visitDate);
+        logger.info("OCR 날짜 추출 결과: '{}'", visitDate);
         
         // 총 금액 추출
         String totalAmount = extractTotalAmount(text);
@@ -319,8 +320,17 @@ public class OcrService {
             addressSimilarity = calculateSimilarity(extractedAddress, expectedAddress);
         }
         
-        // 종합 점수가 0.6 이상이면 검증 통과
-        return (nameSimilarity * 0.8 + addressSimilarity * 0.2) >= 0.6;
+        double overallScore = nameSimilarity * 0.8 + addressSimilarity * 0.2;
+        
+        // 디버깅을 위한 로그 추가
+        logger.info("OCR 검증 - 추출된 식당명: '{}', 예상 식당명: '{}', 유사도: {}", 
+                   extractedRestaurantName, expectedRestaurantName, nameSimilarity);
+        logger.info("OCR 검증 - 추출된 주소: '{}', 예상 주소: '{}', 유사도: {}", 
+                   extractedAddress, expectedAddress, addressSimilarity);
+        logger.info("OCR 검증 - 종합 점수: {}, 임계값: 0.5", overallScore);
+        
+        // 종합 점수가 0.5 이상이면 검증 통과 (기존 0.6에서 완화)
+        return overallScore >= 0.5;
     }
     
     private double calculateConfidence(String extractedRestaurantName, String extractedAddress,

--- a/frontend/components/modals/ReviewWriteModal.tsx
+++ b/frontend/components/modals/ReviewWriteModal.tsx
@@ -101,6 +101,9 @@ export function ReviewWriteModal({ restaurant, onComplete, onCancel }: ReviewWri
         restaurant.addressName || restaurant.address || ''
       )
       
+      console.log('OCR 전체 응답:', result)
+      console.log('OCR 추출된 방문날짜:', result.visitDate)
+      
       // OCR 결과에서 추출한 식당명, 주소, 방문날짜로 자동 업데이트
       if (result.restaurantName && result.restaurantName.trim()) {
         setRestaurantName(result.restaurantName.trim())
@@ -114,12 +117,12 @@ export function ReviewWriteModal({ restaurant, onComplete, onCancel }: ReviewWri
         if (formattedDate) {
           setVisitDate(formattedDate)
         } else {
-          // OCR 날짜 변환에 실패한 경우 오늘 날짜로 설정
-          setVisitDate(new Date().toISOString().split("T")[0])
+          // OCR 날짜 변환에 실패한 경우 사용자가 직접 입력하도록 비워둠
+          setVisitDate("")
         }
       } else {
-        // OCR에서 날짜를 추출하지 못한 경우 오늘 날짜로 설정
-        setVisitDate(new Date().toISOString().split("T")[0])
+        // OCR에서 날짜를 추출하지 못한 경우 사용자가 직접 입력하도록 비워둠
+        setVisitDate("")
       }
       
       setOcrResult(result)

--- a/frontend/components/screens/VisitedRestaurantsScreen.tsx
+++ b/frontend/components/screens/VisitedRestaurantsScreen.tsx
@@ -44,7 +44,7 @@ export default function VisitedRestaurantsScreen() {
 
   const loadCompletedReviews = async () => {
     try {
-      const response = await reviewApi.getUserReviews(1, 10)
+      const response = await reviewApi.getUserReviews(0, 10) // page=0부터 시작
       console.log('작성된 리뷰 데이터:', response) // 디버깅용
       setCompletedReviews(response.data || [])
     } catch (error: any) {


### PR DESCRIPTION
## ✅ 요약
VisitedRestaurantsScreen.tsx:47 - API 호출 시 page를 1에서 0으로 변경
ReviewWriteModal.tsx:117-122 - OCR 날짜 추출 실패 시 오늘 날짜 자동 입력 대신 빈 값으로 두어 사용자가 직접 입력하도록 수정
로그추가해서 확인후 수정예정 
OcrService.java:332 - 검증 임계값을 0.6에서 0.5로 완화
OcrService.java:324-329 - 디버깅 로그 추가하여 검증 과정 추적 가능

## 🧩 변경 내용
- 변경된 주요 파일/폴더
- 추가된 기능/수정된 기능 요약

## 🔍 확인 필요사항 (선택)
테스트가 필요한 부분이나, 다음 작업과 연관되는 부분 정리

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
