### PR TITLE
fix : 중복 정렬키 삭제

### DIFF
--- a/backend/review/src/main/java/com/mapzip/review/entity/ReviewEntity.java
+++ b/backend/review/src/main/java/com/mapzip/review/entity/ReviewEntity.java
@@ -168,7 +168,7 @@ public class ReviewEntity implements java.io.Serializable {
     }
     
     // GSI를 위한 ISO 문자열 형태의 created_at (Terraform과 일치시킴)
-    @DynamoDbSecondarySortKey(indexNames = {"UserIdIndex", "StatusIndex", "RatingIndex", "RecommendationIndex", "AddressIndex"})
+    @DynamoDbSecondarySortKey(indexNames = {"UserIdIndex", "StatusIndex", "RecommendationIndex", "AddressIndex"})
     @DynamoDbAttribute("created_at")
     public String getCreatedAtForGsi() {
         return createdAt != null ? createdAt.toString() : null;


### PR DESCRIPTION
## ✅ 요약
중복 정렬키로 인해 테이블 자체가 제대로 시작 안 됨

## 🧩 변경 내용
- 중복된 정렬키 "RatingIndex" 중 하나 제거 

## 🔍 확인 필요사항 (선택)
테스트가 필요한 부분이나, 다음 작업과 연관되는 부분 정리

## 📝 메모 
내가 기억하고 싶은 내용, 후속 작업 아이디어 등
